### PR TITLE
InputControlsView: virtual joystick stuck fix

### DIFF
--- a/app/src/main/java/com/winlator/cmod/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/cmod/widget/InputControlsView.java
@@ -628,10 +628,11 @@ public class InputControlsView extends View {
                     for (byte i = 0, count = (byte)event.getPointerCount(); i < count; i++) {
                         float x = event.getX(i);
                         float y = event.getY(i);
+                        int pid = event.getPointerId(i);
 
                         handled = false;
                         for (ControlElement element : profile.getElements()) {
-                            if (element.handleTouchMove(i, x, y)) handled = true;
+                            if (element.handleTouchMove(pid, x, y)) handled = true;
                         }
                         if (!handled) touchpadView.onTouchEvent(event);
                     }


### PR DESCRIPTION
The finger index (i) was passed to ACTION_MOVE instead of the actual pointerId, causing the stick to lose track when touching multiple fingers simultaneously. - added int pid = event.getPointerId(i) - handleTouchMove(i, x, y) → handleTouchMove(pid, x, y)