### PR TITLE
Fixes: ignored long-name exes and ArrayIndexException caused by unmapped keycodes

### DIFF
--- a/app/src/main/java/com/winlator/cmod/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/cmod/core/ProcessHelper.java
@@ -276,11 +276,29 @@ public abstract class ProcessHelper {
                 data = br.readLine();
             }
             catch (IOException e) {}
+            if (data == null) data = "";
+            String cmdline = readCmdline(proc, allPids[index]);
+            String haystack = data + " " + cmdline;
             for (String filter : filterList) {
-                if (data.contains(filter))
+                if (haystack.contains(filter)) {
                     filteredPids.add(allPids[index]);
+                    break;  // add each pid at most once (avoids the double-add when it matches both filters)
+                }
             }
         }
         return filteredPids;
+    }
+
+    private static String readCmdline(File proc, String pid) {
+        try (FileInputStream fr = new FileInputStream(proc + "/" + pid + "/cmdline")) {
+            byte[] buf = new byte[512];
+            int n = fr.read(buf);
+            if (n <= 0) return "";
+            StringBuilder sb = new StringBuilder(n);
+            for (int i = 0; i < n; i++) sb.append(buf[i] == 0 ? ' ' : (char) buf[i]);
+            return sb.toString();
+        } catch (Exception e) {
+            return "";
+        }
     }
 }

--- a/app/src/main/java/com/winlator/cmod/xserver/Keyboard.java
+++ b/app/src/main/java/com/winlator/cmod/xserver/Keyboard.java
@@ -98,6 +98,7 @@ public class Keyboard {
 
         int action = event.getAction();
         int keyCode = event.getKeyCode();
+        if (keyCode < 0 || keyCode >= keycodeMap.length) return false; // Ignore unmapped key codes
 
         if (keyCode == KeyEvent.KEYCODE_TAB || keyCode == KeyEvent.KEYCODE_ESCAPE) {
             if (action == KeyEvent.ACTION_DOWN) {


### PR DESCRIPTION
This PR fixes two issues:
1. The pause process does not work with exes whose names are longer than 15 characters, so they remain running.
2. On the _Asus ROG Phone 9_, the game manager sends several keycodes, such as `851` or `861`, when the app goes through Recent Tasks or returns from the background. These values are outside the range of the `keycodeMap` array, which causes an exception and crashes the app.

### 1. Ignored long name exes
When pausing the container while running _Ninja Gaiden Sigma_, the game’s audio can still be heard. Additionally, when checking the status of the container’s processes with adb, they all appear to be paused/stopped (`T`), while _NG Sigma_ appears as `S` or `R`.

adb command: `adb shell ps -eA | Select-String -Pattern "wine", "box64", "wfm", "handler", "testd3d", "ninja", "proton", ".exe", "steam"`

```
u0_a301       1422  1108   10977724  16508 0                   0 T start.exe
u0_a301       1428     1   10776112  16036 0                   0 T wineserver
u0_a301       1521     1   11128368  12004 0                   0 T C:\windows\system32\services.exe
u0_a301       1551     1   10973472  13860 0                   0 T C:\windows\system32\winedevice.exe
u0_a301       1565     1   11038168  15948 0                   0 T C:\windows\system32\plugplay.exe
u0_a301       1574     1   10877568  10924 0                   0 T C:\windows\system32\svchost.exe
u0_a301       1589     1   11005500  17640 0                   0 T C:\windows\system32\winedevice.exe
u0_a301       1599     1   11320028  50832 0                   0 T C:\windows\system32\explorer.exe
u0_a301       1615     1   15841264  23896 0                   0 T winhandler.exe
u0_a301       1627     1   11034592  10924 0                   0 T C:\windows\system32\rpcss.exe
u0_a301       1649     1   35925948 706976 0                   0 S G:\JuegosPC\1_TrueGames\1_BySeries\NinjaGaiden\Ninja Gaiden 1 - Sigma\NINJA GAIDEN SIGMA.exe
```

After Banner’s fix, the game appears as paused in the list.
```
u0_a301      16022 15769   10979772  16724 0                   0 T start.exe
u0_a301      16028     1   10821168  16036 0                   0 T wineserver
u0_a301      16064     1   11017776  12160 0                   0 T C:\windows\system32\services.exe
u0_a301      16067     1   10952992  13388 0                   0 T C:\windows\system32\winedevice.exe
u0_a301      16077     1   10968536  15704 0                   0 T C:\windows\system32\plugplay.exe
u0_a301      16083     1   10959488  10924 0                   0 T C:\windows\system32\svchost.exe
u0_a301      16090     1   11009660  17708 0                   0 T C:\windows\system32\winedevice.exe
u0_a301      16100     1   11389660  48896 0                   0 T C:\windows\system32\explorer.exe
u0_a301      16107     1   15867888  23728 0                   0 T winhandler.exe
u0_a301      16111     1   10936288  10796 0                   0 T C:\windows\system32\rpcss.exe
u0_a301      16122     1   36415780 699760 0                   0 T G:\JuegosPC\1_TrueGames\1_BySeries\NinjaGaiden\Ninja Gaiden 1 - Sigma\NINJA GAIDEN SIGMA.exe
```

### 2. Unmapped keycodes crash
The exception:
```
FATAL EXCEPTION: main
Process: com.winlator
java.lang.ArrayIndexOutOfBoundsException: length=159 index=851
    at com.winlator.xserver.Keyboard.onKeyEvent(Keyboard.java:104)
Caused by: android.view.KeyEvent-JNI: java.lang.IllegalArgumentException: Invalid keycode 851
```

---
The first issue was fixed by The412Banner, so credit goes to him and Claude ([commit](https://github.com/The412Banner/Bannerlator/commit/b1aa7e2782c1525222d36e6c9779d8cf9952a682)).

I fixed the second issue myself and submitted PRs to both [StevenMXZ](https://github.com/StevenMXZ/Winlator-Ludashi/pull/243)’s fork and [Brunodev85](https://github.com/brunodev85/winlator/pull/1996)’s repository when I still wasn’t fully aware of the situation with the forks. My intention is for this fix to be propagated to any potential new forks of this repository.