### PR TITLE
Fixes ANR when paused and shortcut rename.

### DIFF
--- a/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
@@ -1659,7 +1659,6 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
 
     @Override
     public boolean dispatchGenericMotionEvent(MotionEvent event) {
-        if (isPaused) return true;  // Avoid ANR exception when processes are paused.
         boolean handledByWinHandler = false;
         boolean handledByTouchpadView = false;
 

--- a/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/cmod/XServerDisplayActivity.java
@@ -1650,7 +1650,16 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
     }
 
     @Override
+    public boolean dispatchTouchEvent(MotionEvent event) {
+        // Avoid processing touch events when processes are paused and drawer is closed.
+        if (isPaused && (drawerLayout == null || !drawerLayout.isDrawerOpen(GravityCompat.START))) return true;
+
+        return super.dispatchTouchEvent(event);
+    }
+
+    @Override
     public boolean dispatchGenericMotionEvent(MotionEvent event) {
+        if (isPaused) return true;  // Avoid ANR exception when processes are paused.
         boolean handledByWinHandler = false;
         boolean handledByTouchpadView = false;
 

--- a/app/src/main/java/com/winlator/cmod/contentdialog/ShortcutSettingsDialog.java
+++ b/app/src/main/java/com/winlator/cmod/contentdialog/ShortcutSettingsDialog.java
@@ -376,16 +376,6 @@ public class ShortcutSettingsDialog extends ContentDialog {
             String name = etName.getText().toString().trim();
             boolean nameChanged = !shortcut.name.equals(name) && !name.isEmpty();
 
-            // First, handle renaming if the name has changed
-            if (nameChanged) {
-                renameShortcut(name);
-            }
-
-
-            // Determine if renaming is needed
-            boolean renamingSuccess = !nameChanged || new File(shortcut.file.getParent(), name + ".desktop").exists();
-
-            if (renamingSuccess) {
                 String graphicsDriver = StringUtils.parseIdentifier(sGraphicsDriver.getSelectedItem());
                 String displayDriver = StringUtils.parseIdentifier(sDisplayDriver.getSelectedItem());
                 String graphicsDriverConfig = vGraphicsDriverConfig.getTag().toString();
@@ -419,7 +409,7 @@ public class ShortcutSettingsDialog extends ContentDialog {
                     shortcut.putExtra("displayxConfig", vDisplayDriverConfig.getTag().toString());
                 else
                     shortcut.putExtra("eglConfig", vDisplayDriverConfig.getTag().toString());
-                    
+
                 shortcut.putExtra("graphicsDriver", graphicsDriver);
                 shortcut.putExtra("graphicsDriverConfig", graphicsDriverConfig);
                 shortcut.putExtra("dxwrapper", dxwrapper);
@@ -465,6 +455,10 @@ public class ShortcutSettingsDialog extends ContentDialog {
 
                 // Save all changes to the shortcut
                 shortcut.saveData();
+
+            // Last, handle renaming if the name has changed
+            if (nameChanged) {
+                renameShortcut(name);
             }
         });
     }

--- a/app/src/main/java/com/winlator/cmod/contentdialog/ShortcutSettingsDialog.java
+++ b/app/src/main/java/com/winlator/cmod/contentdialog/ShortcutSettingsDialog.java
@@ -376,85 +376,85 @@ public class ShortcutSettingsDialog extends ContentDialog {
             String name = etName.getText().toString().trim();
             boolean nameChanged = !shortcut.name.equals(name) && !name.isEmpty();
 
-                String graphicsDriver = StringUtils.parseIdentifier(sGraphicsDriver.getSelectedItem());
-                String displayDriver = StringUtils.parseIdentifier(sDisplayDriver.getSelectedItem());
-                String graphicsDriverConfig = vGraphicsDriverConfig.getTag().toString();
-                String dxwrapper = StringUtils.parseIdentifier(sDXWrapper.getSelectedItem());
-                String dxwrapperConfig = vDXWrapperConfig.getTag().toString();
-                String audioDriver = StringUtils.parseIdentifier(sAudioDriver.getSelectedItem());
-                String emulator = StringUtils.parseIdentifier(sEmulator.getSelectedItem());
-                String lc_all = etLC_ALL.getText().toString();
-                String midiSoundFont = sMIDISoundFont.getSelectedItemPosition() == 0 ? "" : sMIDISoundFont.getSelectedItem().toString();
-                String screenSize = containerDetailFragment.getScreenSize(getContentView());
+            String graphicsDriver = StringUtils.parseIdentifier(sGraphicsDriver.getSelectedItem());
+            String displayDriver = StringUtils.parseIdentifier(sDisplayDriver.getSelectedItem());
+            String graphicsDriverConfig = vGraphicsDriverConfig.getTag().toString();
+            String dxwrapper = StringUtils.parseIdentifier(sDXWrapper.getSelectedItem());
+            String dxwrapperConfig = vDXWrapperConfig.getTag().toString();
+            String audioDriver = StringUtils.parseIdentifier(sAudioDriver.getSelectedItem());
+            String emulator = StringUtils.parseIdentifier(sEmulator.getSelectedItem());
+            String lc_all = etLC_ALL.getText().toString();
+            String midiSoundFont = sMIDISoundFont.getSelectedItemPosition() == 0 ? "" : sMIDISoundFont.getSelectedItem().toString();
+            String screenSize = containerDetailFragment.getScreenSize(getContentView());
 
-                int finalInputType = 0;
-                finalInputType |= cbEnableXInput.isChecked() ? WinHandler.FLAG_INPUT_TYPE_XINPUT : 0;
-                finalInputType |= cbEnableDInput.isChecked() ? WinHandler.FLAG_INPUT_TYPE_DINPUT : 0;
-                finalInputType |= SDInputType.getSelectedItemPosition() == 0 ?  WinHandler.FLAG_DINPUT_MAPPER_STANDARD : WinHandler.FLAG_DINPUT_MAPPER_XINPUT;
+            int finalInputType = 0;
+            finalInputType |= cbEnableXInput.isChecked() ? WinHandler.FLAG_INPUT_TYPE_XINPUT : 0;
+            finalInputType |= cbEnableDInput.isChecked() ? WinHandler.FLAG_INPUT_TYPE_DINPUT : 0;
+            finalInputType |= SDInputType.getSelectedItemPosition() == 0 ?  WinHandler.FLAG_DINPUT_MAPPER_STANDARD : WinHandler.FLAG_DINPUT_MAPPER_XINPUT;
 
 
-                shortcut.putExtra("inputType", String.valueOf(finalInputType));
+            shortcut.putExtra("inputType", String.valueOf(finalInputType));
 
-                boolean disabledXInput = cbDisabledXInput.isChecked();
-                shortcut.putExtra("disableXinput", disabledXInput ? "1" : null);
+            boolean disabledXInput = cbDisabledXInput.isChecked();
+            shortcut.putExtra("disableXinput", disabledXInput ? "1" : null);
 
-                boolean touchscreenMode = cbSimTouchScreen.isChecked();
-                shortcut.putExtra("simTouchScreen", touchscreenMode ? "1" : "0");
+            boolean touchscreenMode = cbSimTouchScreen.isChecked();
+            shortcut.putExtra("simTouchScreen", touchscreenMode ? "1" : "0");
 
-                String execArgs = etExecArgs.getText().toString();
-                shortcut.putExtra("execArgs", !execArgs.isEmpty() ? execArgs : null);
-                shortcut.putExtra("screenSize", screenSize);
-                shortcut.putExtra("displayDriver", displayDriver);
-                if (displayDriver.equals("displayx"))
-                    shortcut.putExtra("displayxConfig", vDisplayDriverConfig.getTag().toString());
-                else
-                    shortcut.putExtra("eglConfig", vDisplayDriverConfig.getTag().toString());
+            String execArgs = etExecArgs.getText().toString();
+            shortcut.putExtra("execArgs", !execArgs.isEmpty() ? execArgs : null);
+            shortcut.putExtra("screenSize", screenSize);
+            shortcut.putExtra("displayDriver", displayDriver);
+            if (displayDriver.equals("displayx"))
+                shortcut.putExtra("displayxConfig", vDisplayDriverConfig.getTag().toString());
+            else
+                shortcut.putExtra("eglConfig", vDisplayDriverConfig.getTag().toString());
 
-                shortcut.putExtra("graphicsDriver", graphicsDriver);
-                shortcut.putExtra("graphicsDriverConfig", graphicsDriverConfig);
-                shortcut.putExtra("dxwrapper", dxwrapper);
-                shortcut.putExtra("dxwrapperConfig", dxwrapperConfig);
-                shortcut.putExtra("audioDriver", audioDriver);
-                shortcut.putExtra("emulator", emulator);
-                shortcut.putExtra("midiSoundFont", midiSoundFont);
-                shortcut.putExtra("lc_all", lc_all);
+            shortcut.putExtra("graphicsDriver", graphicsDriver);
+            shortcut.putExtra("graphicsDriverConfig", graphicsDriverConfig);
+            shortcut.putExtra("dxwrapper", dxwrapper);
+            shortcut.putExtra("dxwrapperConfig", dxwrapperConfig);
+            shortcut.putExtra("audioDriver", audioDriver);
+            shortcut.putExtra("emulator", emulator);
+            shortcut.putExtra("midiSoundFont", midiSoundFont);
+            shortcut.putExtra("lc_all", lc_all);
 
-                shortcut.putExtra("fullscreenStretched", cbFullscreenStretched.isChecked() ? "1" : null);
+            shortcut.putExtra("fullscreenStretched", cbFullscreenStretched.isChecked() ? "1" : null);
 
-                String wincomponents = containerDetailFragment.getWinComponents(getContentView());
-                shortcut.putExtra("wincomponents", wincomponents);
+            String wincomponents = containerDetailFragment.getWinComponents(getContentView());
+            shortcut.putExtra("wincomponents", wincomponents);
 
-                String envVars = envVarsView.getEnvVars();
-                shortcut.putExtra("envVars", !envVars.isEmpty() ? envVars : null);
+            String envVars = envVarsView.getEnvVars();
+            shortcut.putExtra("envVars", !envVars.isEmpty() ? envVars : null);
 
-                String fexcoreVersion = sFEXCoreVersion.getSelectedItem().toString();
-                shortcut.putExtra("fexcoreVersion", fexcoreVersion);
+            String fexcoreVersion = sFEXCoreVersion.getSelectedItem().toString();
+            shortcut.putExtra("fexcoreVersion", fexcoreVersion);
 
-                String fexcorePreset = FEXCorePresetManager.getSpinnerSelectedId(sFEXCorePreset);
-                shortcut.putExtra("fexcorePreset", fexcorePreset);
+            String fexcorePreset = FEXCorePresetManager.getSpinnerSelectedId(sFEXCorePreset);
+            shortcut.putExtra("fexcorePreset", fexcorePreset);
 
-                String box64Preset = Box64PresetManager.getSpinnerSelectedId(sBox64Preset);
-                shortcut.putExtra("box64Preset", box64Preset);
+            String box64Preset = Box64PresetManager.getSpinnerSelectedId(sBox64Preset);
+            shortcut.putExtra("box64Preset", box64Preset);
 
-                byte startupSelection = (byte)sStartupSelection.getSelectedItemPosition();
-                shortcut.putExtra("startupSelection", String.valueOf(startupSelection));
+            byte startupSelection = (byte)sStartupSelection.getSelectedItemPosition();
+            shortcut.putExtra("startupSelection", String.valueOf(startupSelection));
 
-                String sharpeningEffect = sSharpnessEffect.getSelectedItem().toString();
-                String sharpeningLevel = String.valueOf(sbSharpnessLevel.getProgress());
-                String sharpeningDenoise = String.valueOf(sbSharpnessDenoise.getProgress());
-                shortcut.putExtra("sharpnessEffect", sharpeningEffect);
-                shortcut.putExtra("sharpnessLevel", sharpeningLevel);
-                shortcut.putExtra("sharpnessDenoise", sharpeningDenoise);
+            String sharpeningEffect = sSharpnessEffect.getSelectedItem().toString();
+            String sharpeningLevel = String.valueOf(sbSharpnessLevel.getProgress());
+            String sharpeningDenoise = String.valueOf(sbSharpnessDenoise.getProgress());
+            shortcut.putExtra("sharpnessEffect", sharpeningEffect);
+            shortcut.putExtra("sharpnessLevel", sharpeningLevel);
+            shortcut.putExtra("sharpnessDenoise", sharpeningDenoise);
 
-                ArrayList<ControlsProfile> profiles = inputControlsManager.getProfiles(true);
-                int controlsProfile = sControlsProfile.getSelectedItemPosition() > 0 ? profiles.get(sControlsProfile.getSelectedItemPosition() - 1).id : 0;
-                shortcut.putExtra("controlsProfile", controlsProfile > 0 ? String.valueOf(controlsProfile) : null);
+            ArrayList<ControlsProfile> profiles = inputControlsManager.getProfiles(true);
+            int controlsProfile = sControlsProfile.getSelectedItemPosition() > 0 ? profiles.get(sControlsProfile.getSelectedItemPosition() - 1).id : 0;
+            shortcut.putExtra("controlsProfile", controlsProfile > 0 ? String.valueOf(controlsProfile) : null);
 
-                String cpuList = cpuListView.getCheckedCPUListAsString();
-                shortcut.putExtra("cpuList", cpuList);
+            String cpuList = cpuListView.getCheckedCPUListAsString();
+            shortcut.putExtra("cpuList", cpuList);
 
-                // Save all changes to the shortcut
-                shortcut.saveData();
+            // Save all changes to the shortcut
+            shortcut.saveData();
 
             // Last, handle renaming if the name has changed
             if (nameChanged) {


### PR DESCRIPTION
## Bugs:
- ANR crash when the user continues entering input while processes are paused. Reported in #109.
- When renaming a shortcut and changing other settings, only the new shortcut name is saved while the settings remain unchanged. Reported in #99.

## Fixes:
- **ANR**: In `XServerDisplayActivity`, the `dispatchTouchEvent` method has been added, which ignores touches unrelated to the `drawer`, preventing the _ANR_ and allowing continued use of the menu without issues.
  - The code for this fix is this one:
  ```java
  @Override
    public boolean dispatchTouchEvent(MotionEvent event) {
        // Avoid processing touch events when processes are paused and drawer is closed.
        if (isPaused && (drawerLayout == null || !drawerLayout.isDrawerOpen(GravityCompat.START))) return true;

        return super.dispatchTouchEvent(event);
    }
  ```
- **Shortcut**: The shortcut renaming now occurs after saving the rest of the configuration, thus preserving the changes made by the user and renaming the shortcut afterwards without problems.
  - On this last point, I have a doubt I'd like to review regarding the functionality of the line `386` of the original file:
  ```java
  boolean renamingSuccess = !nameChanged || new File(shortcut.file.getParent(), name + ".desktop").exists();
  ``` 
     Personally, I find it confusing due to how redundant it seems. With the fix applied (line removed), if the user enters a name that already exists in another shortcut, the name doesn't change but the settings do, which seems more beneficial than canceling everything the user has modified.
   - The code for this fix is this one:
   ```java
   
   // Unmodified
   setOnConfirmCallback(() -> {
    String name = etName.getText().toString().trim();
    boolean nameChanged = !shortcut.name.equals(name) && !name.isEmpty();
    
    // Then, conditionals and rename removed and update all settings in the shortcut object first
    shortcut.putExtra("inputType", String.valueOf(finalInputType));
    // (...)
    
    // (Unmodified) Save the settings to the current file
    shortcut.saveData();
    
    // Moved the renaming to after saving the other settings.
    if (nameChanged) {
        renameShortcut(name);
    }
   ```

## Additional notes:
- I've tried to avoid extra changes in the files, but it turns out GitHub is causing these changes. Perhaps the project would benefit from a general reformatting and adding the `.gitattributes` file as indicated [here](https://github.com/orgs/community/discussions/142407#discussioncomment-11033368).
- In the second reported issue, I also mention the problem of creating a shortcut with different exes and the same name. I've discarded that approach because it caused more problems than it solved. I'll provide more details in the issue itself.